### PR TITLE
Patch probes to improve reliability

### DIFF
--- a/file_watcher/main.py
+++ b/file_watcher/main.py
@@ -112,6 +112,7 @@ class FileWatcher:
         Start the PollingObserver with the queue based event handler and the given queue
         :return: None
         """
+        write_readiness_probe_file()
 
         def _event_occurred(path_to_add: Union[Path, None]) -> None:
             if path_to_add is not None:

--- a/file_watcher_operator/file_watcher_operator.py
+++ b/file_watcher_operator/file_watcher_operator.py
@@ -111,7 +111,7 @@ def generate_deployment_body(
                           else
                             exit 1
                           fi
-                      initialDelaySeconds: 10
+                      initialDelaySeconds: 600
                       periodSeconds: 10
                     livenessProbe:
                       exec:
@@ -127,7 +127,7 @@ def generate_deployment_body(
                           else
                             exit 1
                           fi
-                      initialDelaySeconds: 10
+                      initialDelaySeconds: 600
                       failureThreshold: 3
                       periodSeconds: 10
                     volumeMounts:


### PR DESCRIPTION
Closes None, noticed issues in production.

## Description
Notably the liveness and readiness probes are not written till old runs are recovered, and the probes are checked 10 seconds after start leading to crash loops.